### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,39 +16,53 @@ The output of compilation will go to the `:compile-path` directory, which defaul
 
 You may specify additional Frege compiler options via `:fregec-options` in `project.clj` (as a vector of strings) or via the command line. Note that command line options for Leiningen tasks start with `:` (and are converted to `-` options automatically):
 
-    lein fregec :v
+```sh
+lein fregec :v
+```
 
 This will pass `-v` to the Frege compiler (verbose mode). If you want to see the full list of options being passed to the Frege compiler, set the `DEBUG` environment variable to `true`:
 
-    DEBUG=true lein fregec
+```sh
+DEBUG=true lein fregec
+```
 
 This will also display the exact version of the Frege compiler that the plugin is using.
 
 Run `lein uberjar` to compile Frege source files and create a JAR file in the `target/` folder. You need to ensure that Frege compilation is part of the `:uberjar` profile in `project.clj`:
 
-    :profiles {:uberjar {:aot :all
-                         :prep-tasks ["fregec" "compile"]}}
+```clojure
+:profiles {:uberjar {:aot :all
+                     :prep-tasks ["fregec" "compile"]}}
+```
 
 This tells Leiningen to run the `fregec` task and the `compile` task before building the JAR file. That will run the Frege compiler and also compile any Clojure code in the project.
 
 Also, in order to include the Frege runtime in the resulting JAR file, you will need the following dependency in your `project.clj` file:
 
-    :dependencies [[org.frege-lang/frege "3.22.526-gcc99d7e]]
+```clojure
+:dependencies [[org.frege-lang/frege "3.22.526-gcc99d7e"]]
+```
 
 The version here should exactly match that displayed by `lein-fregec` when you use the `DEBUG=true` environment variable!
 
 This tells Leiningen that your project depends on Frege, and it will package it into the standalone JAR it produces. The standalone JAR can be run as follows:
 
-    java -cp target/frege-hello-0.1.0-SNAPSHOT-standalone.jar Hello
+```sh
+java -cp target/frege-hello-0.1.0-SNAPSHOT-standalone.jar Hello
+```
 
 This assumes your `project.clj` starts out like this:
 
-    (defproject frege-hello "0.1.0-SNAPSHOT"
-      ...)
+```clojure
+(defproject frege-hello "0.1.0-SNAPSHOT"
+  ...)
+```
 
 You can also run your (pure Frege) code by specifying `:run` and the class name (followed by any arguments for your `main` method):
 
-    lein fregec :run Hello
+```sh
+lein fregec :run Hello
+```
 
 There will also be a non-standalone JAR will which does not contain the Frege runtime.
 


### PR DESCRIPTION
- replaced indented blocks with tagged code blocks
- added missing " in :dependencies block

I'm pretty much dependent on syntax highlighting..
Also the line re: `:dependencies` was missing a closing `"`.

Even if you're not into the triple back-quote style, the `"` is worth adding.
